### PR TITLE
Fix save screenshot flow for saucelabs

### DIFF
--- a/dummy/.rspec
+++ b/dummy/.rspec
@@ -1,2 +1,2 @@
 --color
---require spec_helper
+--require rails_helper

--- a/dummy/Gemfile
+++ b/dummy/Gemfile
@@ -63,7 +63,7 @@ group :development, :test do
   gem 'poltergeist'
   gem 'percy-capybara'
   gem 'eyes_selenium'
-  gem 'integration-diff', :git => "https://github.com/luthfiswees/integration-diff.rb.git"
+  gem 'integration-diff', :git => "https://github.com/luthfiswees/integration-diff.rb.git", branch: "master"
 end
 
 group :development do

--- a/dummy/Gemfile.lock
+++ b/dummy/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/luthfiswees/integration-diff.rb.git
-  revision: 569a976c104977c13afb13a1d6b44f94e0932b7a
+  revision: 5da7ab46a5f3122bdae69da16094c5bfc32bfecc
+  branch: master
   specs:
     integration-diff (0.2.0)
       faraday

--- a/dummy/db/schema.rb
+++ b/dummy/db/schema.rb
@@ -14,7 +14,7 @@
 ActiveRecord::Schema.define(version: 20160617043651) do
 
   create_table "orders", force: :cascade do |t|
-    t.string   "order_id",   null: false
+    t.string   "order_id"
     t.string   "item1"
     t.string   "item2"
     t.string   "vtweblink"
@@ -25,17 +25,15 @@ ActiveRecord::Schema.define(version: 20160617043651) do
   add_index "orders", ["order_id"], name: "index_orders_on_order_id", unique: true
 
   create_table "pays", force: :cascade do |t|
-    t.string   "order_id",           null: false
+    t.string   "order_id"
     t.string   "payment_type"
     t.string   "transaction_status"
     t.string   "fraud_status"
     t.integer  "gross_amount"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
-    t.integer  "orders_id"
   end
 
   add_index "pays", ["order_id"], name: "index_pays_on_order_id", unique: true
-  add_index "pays", ["orders_id"], name: "index_pays_on_orders_id"
 
 end

--- a/dummy/spec/features/page_renders_spec.rb
+++ b/dummy/spec/features/page_renders_spec.rb
@@ -1,8 +1,3 @@
-require_relative '../rails_helper'
-require_relative '../supports/capturer'
-require 'capybara/rspec'
-require 'eyes_selenium'
-
 describe 'page renders' do
 
 	before :all do
@@ -48,7 +43,6 @@ describe 'page renders' do
 		@current_browser_name = @default_browser_name
 		@current_test_name = "#{@default_app_name} in #{@current_browser_name} by Capturer"
 
-		@current_batch = Applitools::Base::BatchInfo.new("test_name")
 
 		FactoryGirl.create(:order)
 		FactoryGirl.create(:pay)
@@ -99,7 +93,6 @@ describe 'page renders' do
 
 		# @current_browser.get "#{@current_base_url}/demo/index"  
 		# @current_eyes.check_window("#{@current_screenshot_path}/index")
-		byebug
 		visit 'demo/index'
 		idiff.screenshot "home_page"
 		# visit 'demo/store'

--- a/dummy/spec/rails_helper.rb
+++ b/dummy/spec/rails_helper.rb
@@ -1,4 +1,3 @@
-puts ">> in rails_helper.rb"
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)

--- a/dummy/spec/rails_helper.rb
+++ b/dummy/spec/rails_helper.rb
@@ -1,10 +1,10 @@
+puts ">> in rails_helper.rb"
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require_relative '../spec/spec_helper'
-require_relative '../spec/supports/capybara_driver'
+require_relative 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -21,7 +21,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/supports/**/*.rb')].each { |f| require f }
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/dummy/spec/spec_helper.rb
+++ b/dummy/spec/spec_helper.rb
@@ -40,7 +40,7 @@ IntegrationDiff.configure do |config|
     config.api_key = ENV["IDIFF_API_KEY"]
 
     # configure js driver which is used for taking screenshots.
-    config.javascript_driver = "poltergeist"
+    config.javascript_driver = "selenium"
 
     # configure service to mock capturing and uploading screenshots
     config.enable_service = !!ENV["IDIFF_ENABLE"]
@@ -54,16 +54,11 @@ RSpec.configure do |config|
   config.include IntegrationDiff::Dsl
 
   config.before(:suite) do
-    Percy.config.access_token = Rails.application.secrets.percy_access_token
-    Percy::Capybara.initialize_build
-    # byebug
-    IntegrationDiff.rerun ENV['IDIFF_RUN_ID'].to_i
+    IntegrationDiff.start_run
   end
 
   config.after(:suite) do 
-    Percy::Capybara.finalize_build
-    # byebug
-    IntegrationDiff.upload_run 
+    IntegrationDiff.wrap_run 
   end
 
   # rspec-expectations config goes here. You can use an alternate

--- a/dummy/spec/spec_helper.rb
+++ b/dummy/spec/spec_helper.rb
@@ -40,7 +40,7 @@ IntegrationDiff.configure do |config|
     config.api_key = ENV["IDIFF_API_KEY"]
 
     # configure js driver which is used for taking screenshots.
-    config.javascript_driver = "selenium"
+    config.javascript_driver = "poltergeist"
 
     # configure service to mock capturing and uploading screenshots
     config.enable_service = !!ENV["IDIFF_ENABLE"]

--- a/dummy/spec/supports/capybara_driver.rb
+++ b/dummy/spec/supports/capybara_driver.rb
@@ -8,7 +8,6 @@
 # native browser, Second method by using idiff service to set the drivers,
 # and the other by using third party drivers (using SauceLabs).
 # I will display those three writing formats over this documents
-
 case ENV['IDIFF_DRIVER']
 
 ###################################################################################
@@ -36,7 +35,7 @@ when "saucelabs"
 
 	# URL for SauceLabs drivers
 	saucelabs_enable = true
-	sauce_url = "http://#{ENV['SAUCE_USERNAME']}:#{ENV['SAUCE_KEY']}@ondemand.saucelabs.com:80/wd/hub"
+	sauce_url = "http://#{ENV['SAUCE_USERNAME']}:#{ENV['SAUCE_KEY']}@localhost:4445/wd/hub"
 
 	# register your driver capabilities here
 	# Remember, only SauceLabs capability formats that are accepted
@@ -46,14 +45,8 @@ when "saucelabs"
   		:version => "31",
   		:screen_resolution => "1280x1024",
 
-  		:name => IntegrationDiff.name_test( ENV['IDIFF_DRIVER'] )
+  		:name => "TestTest"
 	}
-
-	# setting up the driver over here
-	# This settings will invoke the test environment over the remote
-	@driver = Selenium::WebDriver.for(:remote,
-	   		 	:url => sauce_url,
-	    		:desired_capabilities => capabilities)
 
 	# setting up the browser over here
 	@browser = {
@@ -90,12 +83,6 @@ when "saucelabs_mobile"
 	mobile_capabilities['deviceOrientation'] = 'portrait'
 	mobile_capabilities[:name] = IntegrationDiff.name_test ENV['IDIFF_DRIVER']
 
-	# setting up the driver over here
-	# This settings will invoke the test environment over the remote
-	@mobile_driver = Selenium::WebDriver.for(:remote,
-	   		 	:url => sauce_url,
-	    		:desired_capabilities => mobile_capabilities)
-
 	# setting up the browser over here
 	@mobile_browser = {
 		browser: :remote,
@@ -118,14 +105,6 @@ end
 
 # register the selected drivers as current driver used
 Capybara.current_driver = :used_driver
-
-# if you are using SauceLabs drivers. Please use the code below
-# this code purpose is to connect Capybara with the remote test
-if saucelabs_enable then
-	Capybara.app_host = "#{sauce_url}/test/#{Capybara.current_session.driver.browser.session_id}"
-end
-
-
 
 	# ################################
 	# # capabilities for remote driver

--- a/dummy/spec/supports/capybara_driver.rb
+++ b/dummy/spec/supports/capybara_driver.rb
@@ -45,7 +45,7 @@ when "saucelabs"
   		:version => "31",
   		:screen_resolution => "1280x1024",
 
-  		:name => "TestTest"
+  		:name => IntegrationDiff.name_test( ENV['IDIFF_DRIVER'] )
 	}
 
 	# setting up the browser over here


### PR DESCRIPTION
previously we have 2 problems:
1. Multiple saucelabs webdriver are created when we only run 1 test
2. We cannot access capybara server in localhost (error about session already terminated

---

Why multiple saucelabs created?
- 1st webdriver created for `@driver`
- 2nd webdriver created for `@browser`

I also noticed that `rails_helper` is loaded twice. Still not sure why. But now I fix the require flow
- in every rspec process, `rspec_helper` is always required based on `.rspec`
- no need to `require 'rspec_helper'` in spec files
- every initializer code in `supports/` now always loaded

---

The 2nd problem is obvious. Previous method to access capybara server from saucelabs is deprecated. Now we should use sauce connect.
